### PR TITLE
Moved browser debugger from VSCode extensions to native features

### DIFF
--- a/M4-editors/L2/index.html
+++ b/M4-editors/L2/index.html
@@ -211,6 +211,15 @@
           >here.</a
         >
       </li>
+      <li>
+        <a
+          href="https://code.visualstudio.com/docs/nodejs/browser-debugging"
+          target="_blank"
+          >Browser Debugging</a
+        > 
+        VSCode includes a built-in debugger for Edge and Chrome. Extremely helpful for dealing with front-end development. Read more about it 
+        <a href="https://github.com/microsoft/vscode-js-debug" target="_blank">here</a>.
+      </li>
     </ul>
 
     <p>

--- a/M4-editors/L3/index.html
+++ b/M4-editors/L3/index.html
@@ -79,22 +79,6 @@
 
       <li>
         <a
-          href="https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-chrome"
-          target="_blank"
-          ><b>Debugger for Chrome</b></a
-        >
-        integrates VSCode with your local installation of Chrome to pipe code
-        between the two applications. Extremely helpful for dealing with
-        frontend development,
-        <a
-          href="https://code.visualstudio.com/blogs/2016/02/23/introducing-chrome-debugger-for-vs-code"
-          target="_blank"
-          >read more about it here.</a
-        >
-      </li>
-
-      <li>
-        <a
           href="https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens"
           target="_blank"
           >Gitlens</a


### PR DESCRIPTION
[Debugger for Chrome](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-chrome) VSCode extension is now deprecated in favour of the built-in [VSCode javascript debugger](https://github.com/microsoft/vscode-js-debug).  

Moved chrome debugging item from VSCode Extensions section to Native Features and updated links to point to vscode-js-debug and corresponding VSCode [Browser Debugging](https://code.visualstudio.com/docs/nodejs/browser-debugging) doc.