### PR TITLE
include specific instructions for wsl users

### DIFF
--- a/M5-git/L2/index.html
+++ b/M5-git/L2/index.html
@@ -111,13 +111,18 @@
         >Personal Access Token.</a
       >
       Once you have those, you can
-      <a
-        href="https://docs.github.com/en/github/getting-started-with-github/caching-your-github-credentials-in-git"
-        target="_blank"
-        
-        >follow the instructions here</a
+      <a 
+         href="https://docs.github.com/en/github/getting-started-with-github/caching-your-github-credentials-in-git"
+         target="_blank"
+         >follow the instructions here</a
       >
-      on how to do Credential caching for both Mac and Linux.
+       on how to do Credential caching for both Mac and Linux. 
+      Users of WSL can 
+      <a 
+         href="https://docs.microsoft.com/en-us/windows/wsl/tutorials/wsl-git#git-credential-manager-setup"
+         target="_blank"
+         >follow the instructions here</a
+      > to setup Git Credential Manager Core.
     </p>
 
     <p>


### PR DESCRIPTION
There is a simple command WSL users can input to setup Git Credential Manager Core which is outlined in the Microsoft docs now linked.