### PR TITLE
Add info about APT and Linux Distros

### DIFF
--- a/M2-unix-linux/L2/index.html
+++ b/M2-unix-linux/L2/index.html
@@ -39,10 +39,14 @@
     </p>
 
     <p>
-      Linux's package manager <code>APT</code> is good and we'll learn about it
+      Linux comes with multiples variations which we call distros. One of the most popular one is Ubuntu which we will use throughout the course.
+    </p>
+    
+    <p>
+      Ubuntu Linux's package manager <code>APT</code> is good and we'll learn about it
       below, but MacOS' does not have a native package manager installed. We'll
       go over how to install a third-party package manager for Mac called
-      Homebrew.
+      Homebrew. Please note that other ditros might have different package manager like yum for RedHat & Fedora.
     </p>
 
     <h2>Advanced Package Tool (APT)</h2>


### PR DESCRIPTION
I think telling APT as a default Linux package manager is misleading.